### PR TITLE
Limit the number of scores in the user_feed to 25. Add test for it

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.includes(:user).order(played_at: :desc, id: :desc).limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -9,6 +9,10 @@ describe Api::ScoresController, type: :request do
     @score1 = create(:score, user: @user1, total_score: 79, played_at: '2021-05-20')
     @score2 = create(:score, user: user2, total_score: 99, played_at: '2021-06-20')
     @score3 = create(:score, user: user2, total_score: 68, played_at: '2021-06-13')
+
+    25.times do |i|
+      create(:score, user: @user1, total_score: 100 - i, played_at: '2020-06-10')
+    end
   end
 
   describe 'GET feed' do
@@ -19,7 +23,7 @@ describe Api::ScoresController, type: :request do
       response_hash = JSON.parse(response.body)
       scores = response_hash['scores']
 
-      expect(scores.size).to eq 3
+      expect(scores.size).to eq 25
       expect(scores[0]['user_name']).to eq 'User2'
       expect(scores[0]['total_score']).to eq 99
       expect(scores[0]['played_at']).to eq '2021-06-20'


### PR DESCRIPTION
Fixes: Limited the number of scores that can be shown in the user_feed to 25. Also added a check in the test to see if it works as expected

**Changes**

Changed the user_feed method in the scores controller. Generated another 25 scores in the scores _controller_spec.rb to see if the limit works.
